### PR TITLE
Fix missing index in time info item

### DIFF
--- a/Sources/wallpapper/Generator.swift
+++ b/Sources/wallpapper/Generator.swift
@@ -129,6 +129,7 @@ class Generator {
 
             if let time = item.time {
                 let timeItem = TimeItem()
+                timeItem.i = index
                 timeItem.t = Double(Calendar.current.component(.hour, from: time)) / 24.0
                 sequenceInfo.ti.append(timeItem)
             }


### PR DESCRIPTION
The current version 1.4.1 generates all time info items with the same value of 0 for key `i`:

```
	<key>ti</key>
	<array>
		<dict>
			<key>i</key>
			<integer>0</integer>
			<key>t</key>
			<real>0.375</real>
		</dict>
		<dict>
			<key>i</key>
			<integer>0</integer>
			<key>t</key>
			<real>0.0</real>
		</dict>
		<dict>
			<key>i</key>
			<integer>0</integer>
			<key>t</key>
			<real>0.125</real>
		</dict>
		...
	</array>
``` 

This won't work as the OS is expecting each time info item to have the correct index value corresponding to the image resource. This PR addresses this issue.
