### PR TITLE
Import ImageIO

### DIFF
--- a/Sources/WallpapperLib/DynamicWallpaperGenerator/ImageMetadataGenerator.swift
+++ b/Sources/WallpapperLib/DynamicWallpaperGenerator/ImageMetadataGenerator.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import ImageIO
 
 public class ImageMetadataGenerator {
     private let pictureInfos: [PictureInfo]


### PR DESCRIPTION
This fails to compile on my machine (running macOS 12 beta 2, but I'm not sure whether this also affects older versions or not) due to `CGMutableImageMetadata` not being found in scope. Importing `ImageIO` fixes this, and allows it to build and run with no problems.