### PR TITLE
Allow the same file to appear multiple times

### DIFF
--- a/Sources/WallpapperLib/DynamicWallpaperGenerator/ImageMetadataGenerator.swift
+++ b/Sources/WallpapperLib/DynamicWallpaperGenerator/ImageMetadataGenerator.swift
@@ -19,7 +19,7 @@ public class ImageMetadataGenerator {
             pictureInfo.fileName
         }
         var addedDict = [String: Bool]()
-        return sortedFileNames.filter { addedDict.updateValue(true, forKey: $0) == nil }
+        return sortedFileNames
     }()
     
     init(pictureInfos: [PictureInfo]) {
@@ -85,7 +85,7 @@ public class ImageMetadataGenerator {
                 let sequenceItem = SequenceItem()
                 sequenceItem.altitude = altitude
                 sequenceItem.azimuth = azimuth
-                sequenceItem.imageIndex = self.getImageIndex(fileName: item.fileName)
+                sequenceItem.imageIndex = index
 
                 if sequenceInfo.sequenceItems == nil {
                     sequenceInfo.sequenceItems = []
@@ -96,7 +96,7 @@ public class ImageMetadataGenerator {
 
             if let time = item.time {
                 let timeItem = TimeItem()
-                timeItem.imageIndex = self.getImageIndex(fileName: item.fileName)
+                timeItem.imageIndex = index
                 let hour = Calendar.current.component(.hour, from: time)
                 timeItem.time = Double(hour) / 24.0
 
@@ -119,9 +119,5 @@ public class ImageMetadataGenerator {
 
         let base64PropertyList = plistData.base64EncodedString()
         return base64PropertyList
-    }
-    
-    private func getImageIndex(fileName: String) -> Int {
-        return self.images.firstIndex(of: fileName) ?? 0
     }
 }


### PR DESCRIPTION
When the same file is specified multiple times in the JSON file, only the
first file is considered when generating the output HEIC.
This commit allows the same file to be duplicated in the output HEIC.

This is useful if we want to have the same file appear multiple times, but
with a different times/sun positions.