### PR TITLE
Use PNG files from the current shell directory

### DIFF
--- a/Sources/WallpapperLib/DynamicWallpaperGenerator/WallpaperGenerator.swift
+++ b/Sources/WallpapperLib/DynamicWallpaperGenerator/WallpaperGenerator.swift
@@ -26,7 +26,8 @@ public class WallpaperGenerator {
             let destinationData = NSMutableData()
             if let destination = CGImageDestinationCreateWithData(destinationData, AVFileType.heic as CFString, images.count, nil) {
                 for (index, fileName) in images.enumerated() {
-                    let fileURL = URL(fileURLWithPath: fileName, relativeTo: baseURL)
+                    let callPath = URL(string: FileManager.default.currentDirectoryPath)
+                    let fileURL = URL(fileURLWithPath: fileName, relativeTo: callPath)
 
                     consoleIO.writeMessage("Reading image file: '\(fileURL.absoluteString)'...", to: .debug)
                     guard let orginalImage = NSImage(contentsOf: fileURL) else {


### PR DESCRIPTION
Instead of using PNG files relative to the JSON file passed in as an
argument, use PNG files that are in the current shell directory.

This is useful if we want to cd to different directories and apply the
same JSON to them. Without this change, we would need to have a multiple
copies of the same JSON file.