### PR TITLE
added support for multiple time formats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+Wallpapper easily lets you make your own custom dynamic wallpapers for macos.
+This fork I only made because I needed to make a fix for how the times are specified! (I updated the info below)
+
+
+My goal was to use it to make a dynamic wallpaper showing the skyline of 'Cologne (Germany)' during the course of a day!
+https://dominik.pich.info/CologneDay/ shows the results and the individual images.
+
 # 💻 wallpapper / wallpapper-exif
 
 ![Build Status](https://github.com/mczachurski/wallpapper/workflows/Build/badge.svg)
@@ -137,20 +144,20 @@ For wallpaper which based on OS time `json` file have to have structure like on 
         "fileName": "1.png",
         "isPrimary": true,
         "isForLight": true,
-        "time": "2012-04-23T10:25:43Z"
+        "time": "10:25:43"
     },
     {
         "fileName": "2.png",
-        "time": "2012-04-23T14:32:12Z"
+        "time": "14:32:12"
     },
     {
         "fileName": "3.png",
-        "time": "2012-04-23T18:12:01Z"
+        "time": "18:12:01"
     },
     {
         "fileName": "4.png",
         "isForDark": true,
-        "time": "2012-04-23T20:10:45Z"
+        "time": "20:10:45"
     }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-Wallpapper easily lets you make your own custom dynamic wallpapers for macos.
-This fork I only made because I needed to make a fix for how the times are specified! (I updated the info below)
-
-
-My goal was to use it to make a dynamic wallpaper showing the skyline of 'Cologne (Germany)' during the course of a day!
-https://dominik.pich.info/CologneDay/ shows the results and the individual images.
-
 # 💻 wallpapper / wallpapper-exif
 
 ![Build Status](https://github.com/mczachurski/wallpapper/workflows/Build/badge.svg)

--- a/Sources/Wallpapper/Program.swift
+++ b/Sources/Wallpapper/Program.swift
@@ -36,10 +36,51 @@ class Program {
             self.consoleIO.writeMessage("OK.\n", to: .debug)
             
             let decoder = JSONDecoder()
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-            decoder.dateDecodingStrategy = .formatted(formatter)
-
+            
+            decoder.dateDecodingStrategy = .custom { decoder in
+                let container = try decoder.singleValueContainer()
+                let dateString = try container.decode(String.self)
+                
+                // Try formats in order
+                let formatters: [DateFormatter] = [
+                    {
+                        let f = DateFormatter()
+                        f.locale = Locale(identifier: "en_US_POSIX")
+                        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+                        return f
+                    }(),
+                    {
+                        let f = DateFormatter()
+                        f.locale = Locale(identifier: "en_US_POSIX")
+                        f.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+                        return f
+                    }(),
+                    {
+                        let f = DateFormatter()
+                        f.locale = Locale(identifier: "en_US_POSIX")
+                        f.dateFormat = "HH:mm:ssZ"
+                        return f
+                    }(),
+                    {
+                        let f = DateFormatter()
+                        f.locale = Locale(identifier: "en_US_POSIX")
+                        f.dateFormat = "HH:mm:ss"
+                        return f
+                    }()
+                ]
+                
+                for formatter in formatters {
+                    if let date = formatter.date(from: dateString) {
+                        return date
+                    }
+                }
+                
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Cannot decode date string \(dateString)"
+                )
+            }
+            
             self.consoleIO.writeMessage("Decoding JSON file...", to: .debug)
             let pictureInfos = try decoder.decode([PictureInfo].self, from: inputFileContents)
             self.consoleIO.writeMessage("OK (\(pictureInfos.count) pictures).\n", to: .debug)


### PR DESCRIPTION
I noticed that that wallpapper only understands a format with a timezone.

Macos interprets times as local but the way mapper generates the time to write to the heic, it incorporated the timezone and generated the wrong image times

e.g. even a 00:00:00Z was interpreted as UTC and became 0.33333 for me due to me being in PST (it kept applying the offset of 8h due to the use of NSCalendar apis)

this is where it goes wrong:
https://github.com/mczachurski/wallpapper/blob/baa5fa0ab5564fe3cc657aef8eabe61a205468ac/Sources/WallpapperLib/DynamicWallpaperGenerator/ImageMetadataGenerator.swift#L98

So I allowed it to understand a few formats and made sure that A) existing works
B) new produces right output

e.g.
```
[
    {
        "fileName": "01_0000.heic",
        "time": "00:00:00"
    },
    {
        "fileName": "02_0600_prerise.heic",
        "time": "06:00:00"
    },
    {
        "fileName": "03_0800.heic",
        "time": "08:00:00"
    },
    {
        "fileName": "04_1000.heic",
        "isPrimary": true,
        "isForLight": true,
        "time": "10:00:00"
    },
    {
        "fileName": "05_1600.heic",
        "time": "16:00:00"
    },
    {
        "fileName": "06_1900_sunset.heic",
        "time": "19:00:00"
    },
    {
        "fileName": "07_2200_night.heic",
        "isForDark": true,
        "time": "22:00:00"
    }
]
```
becomes
```
[TIME]
	image index: 1, time: 0.0
	image index: 2, time: 0.25
	image index: 3, time: 0.3333333333333333
	image index: 0, time: 0.4166666666666667
	image index: 4, time: 0.6666666666666666
	image index: 5, time: 0.7916666666666666
	image index: 6, time: 0.9166666666666666
---------------------------------------------------
Metadata key: tiff:TileWidth
	value: 1024
---------------------------------------------------
Metadata key: tiff:TileLength
	value: 960
---------------------------------------------------
Metadata key: iio:hasXMP
	value: True
---------------------------------------------------
Metadata key: tiff:Orientation
	value: 1

[APPERANCE]
	image index: 6, dark
	image index: 3, light
[TIME]
	image index: 1, time: 0.0
	image index: 2, time: 0.25
	image index: 3, time: 0.3333333333333333
	image index: 0, time: 0.4166666666666667
	image index: 4, time: 0.6666666666666666
	image index: 5, time: 0.7916666666666666
	image index: 6, time: 0.9166666666666666
---------------------------------------------------
Metadata key: tiff:TileWidth
	value: 1024
---------------------------------------------------
Metadata key: tiff:TileLength
	value: 960
---------------------------------------------------
Metadata key: iio:hasXMP
	value: True
---------------------------------------------------
Metadata key: tiff:Orientation
	value: 1
```